### PR TITLE
Change color value for text selection background

### DIFF
--- a/themes/palenight-operator.json
+++ b/themes/palenight-operator.json
@@ -92,8 +92,8 @@
     "editorLineNumber.foreground": "#4c5374",
     "editorCursor.foreground": "#7e57c2",
     
-    "editor.selectionBackground": "#32374D",
-    "editor.selectionHighlightBackground": "#2E3250",
+    "editor.selectionBackground": "#72778b",
+    "editor.selectionHighlightBackground": "#40445a",
     "editor.inactiveSelectionBackground": "#7e57c25a",
     "editor.wordHighlightBackground": "#32374D",
     "editor.wordHighlightStrongBackground": "#2E3250",


### PR DESCRIPTION
**Before:**

![code_2017-10-07_13-00-17](https://user-images.githubusercontent.com/22813027/31305847-ad7aeb42-ab60-11e7-98f8-f33e59279958.png)

**After:**

![code_2017-10-07_13-00-50](https://user-images.githubusercontent.com/22813027/31305849-bd93c602-ab60-11e7-85cf-5930d25d63e3.png)


For me, the text selection background was very indistinguishable from the non-selected texts so I changed it to a light color. I am submitting this PR directly from github so I couldn't change color values in other files. You can close this PR and update the color values (similar to mine) yourself.

Thanks.